### PR TITLE
user: optional per-user cli history file

### DIFF
--- a/src/org/freertr/user/userLine.java
+++ b/src/org/freertr/user/userLine.java
@@ -57,6 +57,11 @@ public class userLine {
     public int execHistory = 64;
 
     /**
+     * save command history to file, name is auto generated per user
+     */
+    public boolean execHistFile = false;
+
+    /**
      * rib lines
      */
     public int execRibLines = 8192;
@@ -305,6 +310,7 @@ public class userLine {
         new userFilter(".*", cmds.tabulator + "exec width 79", null),
         new userFilter(".*", cmds.tabulator + "exec height 24", null),
         new userFilter(".*", cmds.tabulator + "exec history 64", null),
+        new userFilter(".*", cmds.tabulator + cmds.negated + cmds.tabulator + "exec histfile", null),
         new userFilter(".*", cmds.tabulator + "exec riblines 8192", null),
         new userFilter(".*", cmds.tabulator + cmds.negated + cmds.tabulator + "exec timestamp", null),
         new userFilter(".*", cmds.tabulator + "exec colorize normal", null),
@@ -508,6 +514,7 @@ public class userLine {
         lst.add(beg + "exec width " + execWidth);
         lst.add(beg + "exec height " + execHeight);
         lst.add(beg + "exec history " + execHistory);
+        cmds.cfgLine(lst, !execHistFile, beg, "exec histfile", "");
         lst.add(beg + "exec riblines " + execRibLines);
         cmds.cfgLine(lst, !execTimes, beg, "exec timestamp", "");
         cmds.cfgLine(lst, !execSpace, beg, "exec spacetab", "");
@@ -626,6 +633,10 @@ public class userLine {
             }
             if (s.equals("history")) {
                 execHistory = bits.str2num(cmd.word());
+                return false;
+            }
+            if (s.equals("histfile")) {
+                execHistFile = true;
                 return false;
             }
             if (s.equals("riblines")) {
@@ -918,6 +929,10 @@ public class userLine {
                 autoCommand = "";
                 return false;
             }
+            if (s.equals("histfile")) {
+                execHistFile = false;
+                return false;
+            }
             if (s.equals("privilege")) {
                 promptPrivilege = 15;
                 return false;
@@ -1041,6 +1056,7 @@ public class userLine {
         l.add(null, false, 3, new int[]{-1}, "<num>", "number of lines");
         l.add(null, false, 2, new int[]{3}, "history", "set history size");
         l.add(null, false, 3, new int[]{-1}, "<num>", "number of lines");
+        l.add(null, false, 2, new int[]{-1}, "histfile", "save history to file per user");
         l.add(null, false, 2, new int[]{3}, "riblines", "set rib buffer size");
         l.add(null, false, 3, new int[]{-1}, "<num>", "number of lines");
         l.add(null, false, 2, new int[]{3}, "ready", "set ready message");
@@ -1347,7 +1363,7 @@ class userLineHandler implements Runnable, Comparable<userLineHandler> {
         userLine.prevUserGlb = s;
         parent.prevUserLoc = s;
         pipe.setTime(parent.execTimeOut);
-        userReader rdr = new userReader(pipe, parent);
+        userReader rdr = new userReader(pipe, parent, user.user);
         pipe.settingsPut(pipeSetting.origin, remote);
         pipe.settingsPut(pipeSetting.authed, user);
         exe = new userExec(pipe, rdr);

--- a/src/org/freertr/user/userReader.java
+++ b/src/org/freertr/user/userReader.java
@@ -35,6 +35,8 @@ public class userReader implements Comparator<String> {
 
     private String[] histD; // history data
 
+    private String histF = ""; // history file, empty means no saving
+
     private int histN; // history number
 
     private String curr; // current line
@@ -222,6 +224,17 @@ public class userReader implements Comparator<String> {
      * @param parent line to use
      */
     public userReader(pipeSide pip, userLine parent) {
+        this(pip, parent, null);
+    }
+
+    /**
+     * constructs new reader for a pipeline
+     *
+     * @param pip pipeline to use as input
+     * @param parent line to use
+     * @param user logged in user, used for per-user history file
+     */
+    public userReader(pipeSide pip, userLine parent, String user) {
         pipe = pip;
         clip = "";
         filterS = "";
@@ -248,6 +261,8 @@ public class userReader implements Comparator<String> {
             return;
         }
         setHistory(parent.execHistory);
+        histF = histFileName(parent.execHistFile, user);
+        loadHistory();
         pipe.settingsAdd(pipeSetting.spacTab, parent.execSpace);
         pipe.settingsAdd(pipeSetting.capsLock, parent.execCaps);
         pipe.settingsAdd(pipeSetting.ansiMode, parent.ansiMode);
@@ -322,6 +337,48 @@ public class userReader implements Comparator<String> {
             }
         }
         histD = d;
+    }
+
+    private static String histFileName(boolean save, String user) {
+        if (!save) {
+            return "";
+        }
+        if (user == null) {
+            user = "";
+        }
+        String s = "";
+        for (int i = 0; i < user.length(); i++) {
+            char c = user.charAt(i);
+            if (!(Character.isLetterOrDigit(c) || (c == '.') || (c == '-') || (c == '_'))) {
+                c = '_';
+            }
+            s += c;
+        }
+        if (s.length() < 1) {
+            s = "_";
+        }
+        return cfgInit.getRWpath() + "hist-" + s + ".txt";
+    }
+
+    private void loadHistory() {
+        if (histF.length() < 1) {
+            return;
+        }
+        List<String> l = bits.txt2buf(histF);
+        if (l == null) {
+            return;
+        }
+        int i = l.size();
+        for (int o = 0; (o < i) && (o < histD.length); o++) {
+            histD[o] = l.get(i - o - 1);
+        }
+    }
+
+    private void saveHistory() {
+        if (histF.length() < 1) {
+            return;
+        }
+        bits.buf2txt(true, getHistory(), histF);
     }
 
     private void findColumn(List<String> lst) {
@@ -1283,6 +1340,7 @@ public class userReader implements Comparator<String> {
                 histD[i + 1] = histD[i];
             }
             histD[0] = a;
+            saveHistory();
         }
         String b = help.repairLine(a);
         if (!help.endOfCmd(b)) {


### PR DESCRIPTION
exec histfile enables saving command history to disk, survives reconnects. filename is auto generated per logged in user under the same rw path write memory uses. off by default.